### PR TITLE
Bug Fix #3

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -27,9 +27,7 @@ let theButtons = document.querySelectorAll("#buttonHolder img"),
 // step 3
 // functionality always goes in the middle -> how do we want
 // the app to behave?
-function changeBGImage() {
-	console.log('Drop Zone empty:', document.querySelector('.drop-zone img') === null);
-    if (document.querySelector('.drop-zone img') === null){
+function changeBGImage() {{
 		puzzleBoard.style.backgroundImage =`url(images/backGround${this.id}.jpg)`;
 	}
 
@@ -38,7 +36,8 @@ puzzlePieces.forEach((piece,index)=> {
 	piece.src=images[index];
 });
 
-
+resetPuzzleBoard();
+}
 	// the `` is a JavaScript template string. It tells the JS enging to evaluate the expression
 	// inside the braces - run that little bit of code. In this case it's just pulling the ID of the
 	// button we clicked on and putting it at the end of the image name (0, 1, 2, 3)
@@ -47,7 +46,7 @@ puzzlePieces.forEach((piece,index)=> {
 	// bug fix #2 should go here. it's at most 3 lines of JS code.
 
 	
-}
+
 
 function handleStartDrag() { 
 	console.log('started dragging this piece:', this);


### PR DESCRIPTION
1. There was an issue with the puzzle board not resetting when you clicked to change the puzzle pieces. the puzzle pieces changed however if there were puzzle pieces existing in the drop zone they would change the images there instead of removing all images from the drop zone and putting the desired puzzle pieces into the div for the puzzle pieces. I fixed that by  addding the "resetPuzzleBoard" command to the "changeBGImage" function.

2. Upon fixing the above issue, I realized that the background image change was delayed and would only change when you clicked it again after it already changed the puzzle piece images. I fixed this by removing the "drop  zone  empty" console.log and the if document.querySelector null's.